### PR TITLE
Fix: Google認証における本番環境でのコールバックurlの変更

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,2 @@
 sorcery:
-  google_callback_url: "https://risk-management-of-children-587c9f9b59e7.herokuapp.com/oauth/callback?provider=google"
+  google_callback_url: "https://www.indoor-baby-guardian.com/oauth/callback?provider=google"


### PR DESCRIPTION
## 概要
Google認証における本番環境のコールバックurlを変更

## Issue
#22

## 確認方法
- ファイル内の確認
1. config/setting/productionファイル内のコールバックurlが変更されているか確認
- 本番環境でのGoogle認証の動作確認
1. https://www.indoor-baby-guardian.com/ で本番環境のアプリを開く
2. Google認証でログインを行い、ログイン後も上記ドメインが前回のドメインになっていないか確認

## 影響範囲
- config/setting/productionファイル
- ログイン機能
    - Google認証

## チェックリスト
- [x] config/setting/productionファイルの修正
- [x] Google APIコンソールの認証情報に登録しているコールバックurlを変更
- [x] 本番環境での動作確認

## コメント
以前までherokuが提供しているドメインを使用していましたが、独自のドメインを取得したため、そちらに変更します。