### PR TITLE
Fix: session_storeファイルの修正

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,8 +1,8 @@
 if Rails.env.production?
   # Production では session_store に Redis を利用する
   Rails.application.config.session_store :redis_store, {
-    servers: ENV['REDIS_URL'],
-    expire_after: 90.minutes,
+    servers: [{ url: ENV['REDIS_URL'], expire_after: 90.minutes }],
+    key: "_risk_management_of_children_session",
     secure: true
   }
 else


### PR DESCRIPTION
## 概要
config/initializers/session_store.rb の修正

## 確認方法
- 本番環境でセッションデータがRedisに保存されているか確認
1. `heroku run bin/rails c`を使用して、redisに接続し、セッションデータの確認を行なってください。

## 影響範囲
- ログイン機能
    - ログイン後のセッション情報の管理場所

## チェックリスト
- [x] config/initializers/session_store.rb の修正

## コメント
本番環境でのセッション管理を heroku-redis で実施できるように修正中です。