### PR TITLE
Fix: コメント・コメント返信フォームのデザイン修正

### DIFF
--- a/app/views/comment_replies/_form.html.erb
+++ b/app/views/comment_replies/_form.html.erb
@@ -9,7 +9,7 @@
     <% end %>
     <div class="mb-2">
       <%= f.label :body, class: "form-label visually-hidden" %>
-      <%= f.text_area :body, class: "form-control rounded shadow-lg", rows: 2, placeholder: "#{CommentReply.human_attribute_name(:body)} #{t("comment_replies.index.body_limit")}" %>
+      <%= f.text_area :body, class: "form-control rounded shadow-lg", rows: 3, placeholder: "#{CommentReply.human_attribute_name(:body)} #{t("comment_replies.index.body_limit")}" %>
     </div>
     <div class="card mb-2 shadow-lg" data-controller="comment-reply-image">
       <div class="row g-0 justify-content-center">

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -3,7 +3,7 @@
     <%= render "shared/error_messages", object: f.object %>
     <div class="mb-2">
       <%= f.label :body, class: "form-label visually-hidden" %>
-      <%= f.text_area :body, class: "form-control rounded shadow-lg", rows: 2, placeholder: "#{Comment.human_attribute_name(:body)} #{t("comment_replies.index.body_limit")}" %>
+      <%= f.text_area :body, class: "form-control rounded shadow-lg", rows: 3, placeholder: "#{Comment.human_attribute_name(:body)} #{t("comment_replies.index.body_limit")}" %>
     </div>
     <div class="card mb-2 shadow-lg" data-controller="comment-image">
       <div class="row g-0 justify-content-center">


### PR DESCRIPTION
## 概要
コメント・コメント返信フォームのデザイン修正

## Issue
#113

## 確認方法
- アプリの準備 & 起動
1. bin/devでサーバーを起動 
2. brew services start redis で redis を起動
3. bundle exec sidekiq -C config/sidekiq.yml で sidekiq を起動
4. http://localhost:3000/ でアプリにアクセス
- コメント・コメント返信機能
1. 入力ホームの高さが3行分の高さであることを確認

## 影響範囲
- コメント・コメント返信機能
1. 入力フォームの高さを変更しました。

## チェックリスト
- [ ] コメント投稿フォームの高さ変更
- [ ] コメント返信の投稿フォームの高さ変更

## コメント
フォームの高さが小さく入力しずらかったため、修正しました。